### PR TITLE
feat: create new gh action to retag container image

### DIFF
--- a/.github/actions/image-retag/action.yml
+++ b/.github/actions/image-retag/action.yml
@@ -1,0 +1,19 @@
+name: Image Retag
+description: Pull container image, create new tag, and then push to target registry.
+inputs:
+  image_source:
+    description: 'The source image to pull.'
+    required: true
+  image_target:
+    description: 'The target image to tag and push.'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Pull docker images
+      run: docker pull ${{ inputs.image_source }}
+    - name: Tag docker images
+      run: docker tag ${{ inputs.image_source }} ${{ inputs.image_target }}
+    - name: Push docker images
+      run: docker push ${{ inputs.image_target }}

--- a/.github/actions/image-retag/action.yml
+++ b/.github/actions/image-retag/action.yml
@@ -12,8 +12,11 @@ runs:
   using: composite
   steps:
     - name: Pull docker images
+      shell: bash
       run: docker pull ${{ inputs.image_source }}
     - name: Tag docker images
+      shell: bash
       run: docker tag ${{ inputs.image_source }} ${{ inputs.image_target }}
     - name: Push docker images
+      shell: bash
       run: docker push ${{ inputs.image_target }}


### PR DESCRIPTION
Really rough draft for GH actions retag container


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the "Image Retag" GitHub Action to streamline container image management by automatically pulling an image, tagging it with a new identifier, and pushing it to a target registry.
	- Now you can easily specify both the source image and the new target image when using the action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->