### PR TITLE
feat: action to rollback cloud run if health check fails

### DIFF
--- a/.github/actions/deploy-cloud-run/action.yml
+++ b/.github/actions/deploy-cloud-run/action.yml
@@ -63,7 +63,7 @@ runs:
         done
 
     - name: Rollback
-      if: ${{ steps.health_check.outputs.error }}
+      if: ${{ steps.health_check.outputs.error && steps.get_revision.outputs.revision }}
       shell: bash
       run: |
         gcloud run services update-traffic "${{ inputs.service }}" \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a GitHub Action for deploying Cloud Run services with built-in rollback support.
	- The action accepts essential deployment inputs (region, image, service) along with an optional health check URL, ensuring smoother deployments with automatic remediation when health checks fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->