### PR TITLE
feat: remove installation step from go license check

### DIFF
--- a/license-checker/go/action.yml
+++ b/license-checker/go/action.yml
@@ -10,13 +10,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
-      with:
-        go-version-file: ${{ inputs.subdirectory }}/go.mod
-        check-latest: true
-        cache-dependency-path: |
-          ${{ inputs.subdirectory }}/go.sum
     - name: Install go-licenses
       shell: bash
       run: go install github.com/google/go-licenses@v1.6.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the workflow to start license compliance checks without automatically setting up the Go environment or checking out the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->