### PR TITLE
feat: dynamic allow license input for npm

### DIFF
--- a/license-checker/npm/action.yml
+++ b/license-checker/npm/action.yml
@@ -27,4 +27,4 @@ runs:
       run: |
         license-checker-rseidelsohn --excludePrivatePackages --production \
           --clarificationsFile ${{ inputs.clarifications_file }} \
-          --onlyAllow "MIT;Apache;ISC;BSD;Python;CC;Public Domain;BlueOak;Unlicense;${{ inputs.allowed_licenses }}"
+          --onlyAllow "MIT;Apache;ISC;BSD;Python;CC;Public Domain;BlueOak;Unlicense;MPL;${{ inputs.allowed_licenses }}"

--- a/license-checker/npm/action.yml
+++ b/license-checker/npm/action.yml
@@ -8,7 +8,7 @@ inputs:
     required: false
   allowed_licenses:
     description: Allowed license types (semicolon separated)
-    default: MIT;Apache;ISC;BSD;Python;CC;Public Domain;BlueOak;Unlicense
+    default: ''
     required: false
   clarifications_file:
     description: File to clarify package license
@@ -27,4 +27,4 @@ runs:
       run: |
         license-checker-rseidelsohn --excludePrivatePackages --production \
           --clarificationsFile ${{ inputs.clarifications_file }} \
-          --onlyAllow "${{ inputs.allowed_licenses }}"
+          --onlyAllow "MIT;Apache;ISC;BSD;Python;CC;Public Domain;BlueOak;Unlicense;${{ inputs.allowed_licenses }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the handling of allowed licenses in the license checker workflow to ensure the original set of approved licenses is always included, now with an expanded default list and the option to add more via input. No visible changes to user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->