### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: actions
+  namespace: reearth
+  description: Collection of actions and reusable workflows for GitHub Actions.
+  annotations:
+    github.com/project-slug: reearth/actions
+  links:
+  - url: https://github.com/reearth/actions
+    title: GitHub
+    icon: github
+  tags:
+  - javascript
+spec:
+  type: service
+  lifecycle: production
+  owner: reearth/sre


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `actions` (namespace `reearth`)
- **Owner:** `reearth/sre`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.