### PR TITLE
feat(compliance-check): add per-repo git-cascade compliance action

### DIFF
--- a/compliance-check/README.md
+++ b/compliance-check/README.md
@@ -18,7 +18,7 @@ git-cascade scan --org <owner> --include-repo <repo> --config-repo eukarya-inc/c
 
 git-cascade reads the configuration from `eukarya-inc/compliance` and reads the
 target repository's contents **through the GitHub API**. It exits `1` when an
-`error`-severity rule fails (`warning`/`info` failures keep exit `0`), which
+`error`-severity rule fails (`warning`/`info` results keep exit `0`), which
 fails the workflow.
 
 > [!IMPORTANT]

--- a/compliance-check/README.md
+++ b/compliance-check/README.md
@@ -1,0 +1,102 @@
+# compliance-check
+
+Runs the org-wide [git-cascade](https://github.com/eukarya-inc/git-cascade)
+compliance rules against a single repository in CI and **fails the job** when
+any `error`-severity rule fails. It uses the same ruleset as the weekly
+[eukarya-inc/compliance](https://github.com/eukarya-inc/compliance) scan
+(`actions-pinned`, `license-exists`, `secret-detection`, `no-secrets-inherit`,
+…), scoped to one repository, so violations surface at merge time instead of
+waiting for the scheduled scan.
+
+## How it works
+
+The action installs the `git-cascade` CLI and runs:
+
+```
+git-cascade scan --org <owner> --include-repo <repo> --config-repo eukarya-inc/compliance
+```
+
+git-cascade reads the configuration from `eukarya-inc/compliance` and reads the
+target repository's contents **through the GitHub API**. It exits `1` when an
+`error`-severity rule fails (`warning`/`info` failures keep exit `0`), which
+fails the workflow.
+
+> [!IMPORTANT]
+> git-cascade always reads the **default branch** of the scanned repository via
+> the API — it cannot read a feature branch or a PR head. Practical
+> consequences:
+>
+> - On `push` to the default branch (i.e. right after a PR is merged) it checks
+>   the **just-merged** state. This is the authoritative gate.
+> - On `pull_request` it checks the **base branch**, not the PR's proposed
+>   changes, so it will not catch a violation introduced by the PR until after
+>   merge. Use it as an early signal only.
+
+## Authentication
+
+git-cascade lists the organization's repositories and then reads repository
+contents (and, for some rules, branch protection and collaborators). For full
+parity with the scheduled scan, supply a **GitHub App token** with:
+
+- Organization → Members: **Read**
+- Repository → Metadata, Contents, Administration: **Read**
+
+Issues write is **not** required — this action does not post issues.
+
+Provide `app-id` + `private-key` and the action mints the token for you, or pass
+a pre-generated `token`. The default `GITHUB_TOKEN` works for the content-based
+rules (`actions-pinned`, `license-exists`, `secret-detection`, …) but lacks
+org/admin scope, so `branch-protection` and `external-collaborators` will error.
+
+## Usage
+
+Recommended: run on `push` to the default branch (authoritative, post-merge),
+with `pull_request` as an optional early signal.
+
+```yaml
+name: Compliance Check
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  compliance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: reearth/actions/compliance-check@main
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+```
+
+Minimal (default `GITHUB_TOKEN`, content rules only):
+
+```yaml
+      - uses: reearth/actions/compliance-check@main
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `app-id` | no | `""` | GitHub App ID/client ID. Use with `private-key` to mint a token. |
+| `private-key` | no | `""` | GitHub App private key (PEM) paired with `app-id`. |
+| `token` | no | `${{ github.token }}` | Pre-generated token used when `app-id`/`private-key` are unset. |
+| `owner` | no | `${{ github.repository_owner }}` | Organization login to scan. |
+| `repo` | no | `${{ github.event.repository.name }}` | Repository short name to scan. |
+| `config-repo` | no | `eukarya-inc/compliance` | Repository holding the git-cascade config. |
+| `config-ref` | no | `""` | Git ref of the config repo (empty = default branch). |
+| `git-cascade-version` | no | `v0.11.3` | git-cascade release tag to install. |
+| `concurrency` | no | `5` | Concurrent (rule, repo) checks. |
+| `format` | no | `table` | Output format: `table`, `json`, `csv`, `sarif`. |
+| `output` | no | `""` | Write results to this file instead of stdout. |
+
+## Suppressing false positives
+
+For line-based rules, add a `git-cascade:allow` comment on the flagged line (see
+the [git-cascade docs](https://github.com/eukarya-inc/git-cascade#suppressing-false-positives)).

--- a/compliance-check/action.yml
+++ b/compliance-check/action.yml
@@ -1,0 +1,112 @@
+name: Compliance Check (git-cascade)
+description: >
+  Run the org-wide git-cascade compliance rules against a single repository in
+  CI and fail the job when any error-severity rule fails. Mirrors the weekly
+  eukarya-inc/compliance scan, scoped to one repository, so violations surface
+  at merge time instead of waiting for the scheduled scan.
+
+inputs:
+  app-id:
+    description: >
+      GitHub App ID (or client ID) used to mint an installation token with
+      org/repo read access. Provide this together with `private-key`. When both
+      are set, the action generates a token and ignores `token`.
+    required: false
+    default: ""
+  private-key:
+    description: "GitHub App private key (PEM) paired with `app-id`."
+    required: false
+    default: ""
+  token:
+    description: >
+      Pre-generated token to use when `app-id`/`private-key` are not provided.
+      git-cascade lists the org's repositories and reads repo contents, so the
+      token needs Organization Members: read and Repository Contents +
+      Administration: read. The default `GITHUB_TOKEN` lacks org/admin scope, so
+      rules such as branch-protection and external-collaborators will error —
+      prefer a GitHub App token for full parity with the scheduled scan.
+    required: false
+    default: ${{ github.token }}
+  owner:
+    description: "Organization login to scan. Defaults to the current repository owner."
+    required: false
+    default: ${{ github.repository_owner }}
+  repo:
+    description: >
+      Repository short name (without owner) to scan. Defaults to the current
+      repository.
+    required: false
+    default: ${{ github.event.repository.name }}
+  config-repo:
+    description: "Repository holding the git-cascade compliance config."
+    required: false
+    default: eukarya-inc/compliance
+  config-ref:
+    description: "Git ref of the config repo. Empty = the config repo's default branch."
+    required: false
+    default: ""
+  git-cascade-version:
+    description: "git-cascade release tag to install."
+    required: false
+    default: v0.11.3
+  concurrency:
+    description: "Number of concurrent (rule, repo) checks."
+    required: false
+    default: "5"
+  format:
+    description: "Output format: table, json, csv, or sarif."
+    required: false
+    default: table
+  output:
+    description: "Write results to this file instead of stdout. Empty = stdout."
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Generate GitHub App token
+      id: app-token
+      if: ${{ inputs.app-id != '' && inputs.private-key != '' }}
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: ${{ inputs.owner }}
+
+    - name: Install git-cascade
+      uses: jaxxstorm/action-install-gh-release@25e24d2d23ae098373794ef1d6faecb48ee52da8 # v3.0.0
+      with:
+        repo: eukarya-inc/git-cascade
+        tag: ${{ inputs.git-cascade-version }}
+
+    - name: Run compliance scan with git-cascade
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ steps.app-token.outputs.token || inputs.token }}
+        OWNER: ${{ inputs.owner }}
+        REPO: ${{ inputs.repo }}
+        CONFIG_REPO: ${{ inputs.config-repo }}
+        CONFIG_REF: ${{ inputs.config-ref }}
+        CONCURRENCY: ${{ inputs.concurrency }}
+        FORMAT: ${{ inputs.format }}
+        OUTPUT: ${{ inputs.output }}
+      run: |
+        set -euo pipefail
+        args=(
+          scan
+          --org "$OWNER"
+          --include-repo "$REPO"
+          --config-repo "$CONFIG_REPO"
+          --concurrency "$CONCURRENCY"
+          --format "$FORMAT"
+        )
+        if [ -n "$CONFIG_REF" ]; then
+          args+=(--config-ref "$CONFIG_REF")
+        fi
+        if [ -n "$OUTPUT" ]; then
+          args+=(--output "$OUTPUT")
+        fi
+        # git-cascade exits 1 when any error-severity rule fails, which fails
+        # this step (and the job). warning/info failures keep exit 0.
+        git-cascade "${args[@]}"

--- a/compliance-check/action.yml
+++ b/compliance-check/action.yml
@@ -108,5 +108,5 @@ runs:
           args+=(--output "$OUTPUT")
         fi
         # git-cascade exits 1 when any error-severity rule fails, which fails
-        # this step (and the job). warning/info failures keep exit 0.
+        # this step (and the job). warning/info results keep exit 0.
         git-cascade "${args[@]}"


### PR DESCRIPTION
## Overview

Adds a `compliance-check` composite action that runs the org-wide [git-cascade](https://github.com/eukarya-inc/git-cascade) compliance ruleset — the same one used by the weekly [eukarya-inc/compliance](https://github.com/eukarya-inc/compliance) scan — against a single repository in CI, and **fails the job** on any `error`-severity violation.

Motivation: today violations (e.g. `actions-pinned`) are only surfaced by the weekly scheduled scan, which posts to [compliance#3](https://github.com/eukarya-inc/compliance/issues/3). This action lets each repo self-check at merge time so regressions are caught immediately.

## What it does

Installs `git-cascade` and runs:

```
git-cascade scan --org <owner> --include-repo <repo> --config-repo eukarya-inc/compliance
```

git-cascade exits `1` when an `error`-severity rule fails, failing the workflow. `warning`/`info` failures keep exit `0`.

## Design notes

- **Auth**: mirrors the scheduled scan. Mints a GitHub App token from `app-id` + `private-key` (org Members read + repo Contents/Administration read), or accepts a pre-generated `token` (defaults to `GITHUB_TOKEN`). Issues write is not needed — this action does not post issues. Pins `actions/create-github-app-token` and `jaxxstorm/action-install-gh-release` to the same SHAs the compliance workflow uses.
- **Default-branch limitation** (documented in the action README): git-cascade reads the scanned repo's **default branch via the GitHub API** — it cannot read a PR head. So `push` to the default branch (right after merge) is the authoritative gate; `pull_request` reads the base branch and is an early signal only.

## Usage

```yaml
name: Compliance Check
on:
  push:
    branches: [main]
  pull_request:
  workflow_dispatch:
permissions:
  contents: read
jobs:
  compliance:
    runs-on: ubuntu-latest
    steps:
      - uses: reearth/actions/compliance-check@main
        with:
          app-id: ${{ vars.GH_APP_ID }}
          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
```

## Out of scope

Wiring the consumer workflow into individual repositories (e.g. reearth-cloud) is a follow-up, per the requester's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)